### PR TITLE
Feature: cambiar color de ciculo a violeta

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,7 +132,7 @@ export default function CountdownApp() {
               cx="128"
               cy="128"
               r="100"
-              stroke="#FF4C4C"
+              stroke="8A2BE2"
               strokeWidth="12"
               fill="none"
               strokeDasharray={628}


### PR DESCRIPTION
- Qué hace este cambio: “Se cambia el color del aro de progreso de rojo (#FF4C4C) a violeta (#8A2BE2).”

- Por qué: “Para darle un tono más suave y alinearse con la guía de estilo.”

- Cómo probarlo: “Arrancar la app, pulsar Iniciar y ver el aro violeta moverse.”

- Pasos para probar

npm run dev

Ver la app en el navegador

Pulsar “Iniciar” y confirmar que el aro sea violeta.